### PR TITLE
Add Play 2.4 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ resolvers ++= Seq(
   "Local Maven" at "file://" + Path.userHome.absolutePath + "/.m2/repository"
 )
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.6"
 
 //disable doc gen this is broken @ mom
 publishArtifact in (Compile, packageDoc) := false
@@ -20,13 +20,15 @@ publishArtifact in (Compile, packageDoc) := false
 libraryDependencies ++= Seq(
    "com.typesafe.play" %% "play" % "2.4.0",
    "com.typesafe.play" %% "play-java" % "2.4.0",
-   "com.sun.jersey" % "jersey-core" % "1.18.1",
+   "com.sun.jersey" % "jersey-core" % "1.19",
    // spring data stuff
-   "org.springframework" % "spring-context" % "4.1.1.RELEASE",
-   "org.springframework.data" % "spring-data-neo4j" % "3.3.0.RC1",
-   "org.springframework.data" % "spring-data-neo4j-rest" % "3.3.0.RC1",
+   "org.springframework" % "spring-context" % "4.1.6.RELEASE",
+   "org.springframework.data" % "spring-data-neo4j" % "3.4.0.M1",
+   "org.springframework.data" % "spring-data-neo4j-rest" % "3.4.0.M1",
    // neo4j stuff
-   "org.neo4j" % "neo4j" % "2.1.7"
+   "org.neo4j" % "neo4j" % "2.3.0-M02",
+   // Inject stuff
+   "javax.inject" % "javax.inject" % "1"
 )
 
 publishTo <<= version {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.8

--- a/src/main/java/neo4jplugin/Neo4JPlugin.java
+++ b/src/main/java/neo4jplugin/Neo4JPlugin.java
@@ -10,6 +10,7 @@ import play.Plugin;
 import play.api.Play;
 
 import java.lang.annotation.Annotation;
+import javax.inject.Inject;
 
 /**
  * @author tuxburner
@@ -29,6 +30,7 @@ public class Neo4JPlugin extends Plugin {
 
     private static Class<?> serviceProviderClass = null;
 
+    @Inject
     public Neo4JPlugin(Application application) {
         this.application = application;
     }


### PR DESCRIPTION
Upgrade scala, sbt and all dependency versions to latest available in order to avoid lib evictions and version mismatches with Play 2.4 dependencies. 
Add javax.inject.Inject to fix plugin constructor due to Play 2.4 DI requirements.

Fixes https://github.com/tuxBurner/play-neo4jplugin/issues/16